### PR TITLE
feat: extend JWT token expiration to 30 days

### DIFF
--- a/apps/edge-server/src/routes/auth/login.ts
+++ b/apps/edge-server/src/routes/auth/login.ts
@@ -39,13 +39,14 @@ loginRoute.post("/", async (c) => {
   if (!isValid) {
     return c.json({ error: "Invalid credentials" }, 401);
   }
-
-  // Create a JWT token (expires in 1 hour).
+  
+  // Create a JWT token (expires in 30 days).
   const tokenPayload: JWTPayload = {
     sub: user.id,
     email: user.email,
-    exp: Math.floor(Date.now() / 1000) + 3600,
+    exp: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60, // 30 days in seconds
   };
+
   const token = await signJWT(tokenPayload, c.env.JWT_SECRET);
   return c.json({ message: "Login successful", token });
 });


### PR DESCRIPTION
This pull request includes a significant change to the JWT token expiration policy in the `loginRoute.post` function within the `apps/edge-server/src/routes/auth/login.ts` file. The most important change is the modification of the token's expiration time from 1 hour to 30 days.

Changes to JWT token expiration:

* [`apps/edge-server/src/routes/auth/login.ts`](diffhunk://#diff-9480b4c99ca7a3c004068d7f83e3cda72e8a9e26734d868690d93afe474eca87L43-R49): Updated the JWT token expiration time from 1 hour to 30 days by modifying the `exp` field in the `tokenPayload` object.